### PR TITLE
Line 82 now uses the correct length.

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -79,7 +79,7 @@ begin:
 		if svc == endpoint {
 			copy(service[version][i:], service[version][i+1:])
 			service[version][len(service[version])-1] = ""
-			service[version] = service[version][:len(service)-1]
+			service[version] = service[version][:len(service[version])-1]
 			goto begin
 		}
 	}


### PR DESCRIPTION
Before, it was using the length of r[name], not r[name][version].

Without this fix, I had two endpoints registered and when deleting one, both would be deleted.  Now, only one is deleted.
