### PR TITLE
seed before generate random number

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -63,7 +63,9 @@ func loadBalance(network, serviceName, serviceVersion string, reg registry.Regis
 			break
 		}
 		// Select a random endpoint
-		i := rand.Int() % len(endpoints)
+		rand.Seed(time.Now().Unix())
+		i := rand.Intn(len(endpoints))
+		// i := rand.Int() % len(endpoints)
 		endpoint := endpoints[i]
 
 		// Try to connect

--- a/goproxy.go
+++ b/goproxy.go
@@ -65,7 +65,6 @@ func loadBalance(network, serviceName, serviceVersion string, reg registry.Regis
 		// Select a random endpoint
 		rand.Seed(time.Now().Unix())
 		i := rand.Intn(len(endpoints))
-		// i := rand.Int() % len(endpoints)
 		endpoint := endpoints[i]
 
 		// Try to connect


### PR DESCRIPTION
Hi creack:
I saw [this example](https://golang.org/pkg/math/rand/) in go documentation, before generate random number,  they use `rand.Seed( )`

maybe it works fine without  `rand.Seed()`, but this seems to be a convention.

thanks for you project!